### PR TITLE
MIgrated to Features 0.3 final release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ stream = ["bytes"]
 
 [dependencies]
 log = "0.4"
-futures-preview = { version = "0.3.0-alpha.19", features = ["async-await"] }
+futures = "0.3.0"
 pin-project = "0.4.0-alpha.9"
 tokio-io = "0.2.0-alpha.6"
 


### PR DESCRIPTION
NOTE: Mixing the use of `futures 0.3` and `futures-preview 0.3` may end up with the following "cryptic" message:

```
error[E0599]: no method named `split` found for type `tokio_tungstenite::WebSocketStream<tokio_tungstenite::stream::Stream<tokio_net::tcp::stream::TcpStream, tokio_tls::TlsStream<tokio_net::tcp::stream::TcpStream>>>` in the current scope
  --> src/main.rs:77:44
   |
77 |     let (mut ws_tx, mut ws_rx) = ws_stream.split();
   |                                            ^^^^^ method not found in `tokio_tungstenite::WebSocketStream<tokio_tungstenite::stream::Stream<tokio_net::tcp::stream::TcpStream, tokio_tls::TlsStream<tokio_net::tcp::stream::TcpStream>>>`
   |
   = note: the method `split` exists but the following trait bounds were not satisfied:
           `&mut tokio_tungstenite::WebSocketStream<tokio_tungstenite::stream::Stream<tokio_net::tcp::stream::TcpStream, tokio_tls::TlsStream<tokio_net::tcp::stream::TcpStream>>> : futures_util::stream::stream::StreamExt`
           `&tokio_tungstenite::WebSocketStream<tokio_tungstenite::stream::Stream<tokio_net::tcp::stream::TcpStream, tokio_tls::TlsStream<tokio_net::tcp::stream::TcpStream>>> : futures_util::stream::stream::StreamExt`
           `tokio_tungstenite::WebSocketStream<tokio_tungstenite::stream::Stream<tokio_net::tcp::stream::TcpStream, tokio_tls::TlsStream<tokio_net::tcp::stream::TcpStream>>> : futures_util::stream::stream::StreamExt`
   = help: items from traits can only be used if the trait is in scope
help: the following trait is implemented but not in scope; perhaps add a `use` for it:
   |
13 | use futures_util::stream::StreamExt;
   |
```

It took me a few moments to realize what happened (since `tokio-tungstenite` does not re-export `futures`, I have to manage `futures` crate myself, and once I updated my own `Cargo.toml`, I ended up with two versions of StreamExt which are incompatible).