### PR TITLE
Don't leak AllowStd type outside the crate

### DIFF
--- a/src/compat.rs
+++ b/src/compat.rs
@@ -10,7 +10,7 @@ pub(crate) trait HasContext {
     fn set_context(&mut self, context: (bool, *mut ()));
 }
 #[derive(Debug)]
-pub struct AllowStd<S> {
+pub(crate) struct AllowStd<S> {
     pub(crate) inner: S,
     pub(crate) context: (bool, *mut ()),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,7 +273,6 @@ impl<S> WebSocketStream<S> {
 impl<T> Stream for WebSocketStream<T>
 where
     T: AsyncRead + AsyncWrite + Unpin,
-    AllowStd<T>: Read + Write,
 {
     type Item = Result<Message, WsError>;
 
@@ -297,7 +296,6 @@ where
 impl<T> Sink<Message> for WebSocketStream<T>
 where
     T: AsyncRead + AsyncWrite + Unpin,
-    AllowStd<T>: Read + Write,
 {
     type Error = WsError;
 


### PR DESCRIPTION
~~Otherwise it can happen that the write part is used by two tasks at the
same time, which then causes only one of them to be woken up and
the other one to wait forever. It is not allowed to use one of the parts
in multiple tasks at the same time.~~

~~As a result, also remove the accessors to the inner stream as these
can't be directly implemented anymore and even otherwise usage would
likely cause buggy behaviour like the above.~~

Does not actually fix the problem. So let's keep this PR around for the one remaining commit that makes sense IMHO: not leaking the `AllowStd` type outside the crate.